### PR TITLE
fix submodule clone url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/scorep_plugin_cxx_wrapper"]
 	path = lib/scorep_plugin_cxx_wrapper
-	url = git@github.com:score-p/scorep_plugin_cxx_wrapper.git
+	url = https://github.com/score-p/scorep_plugin_cxx_wrapper.git
 [submodule "lib/metricq"]
 	path = lib/metricq
 	url = https://github.com/metricq/metricq-cpp.git


### PR DESCRIPTION
The previous clone URL for scorep_plugin_cxx_wrapper required SSH with standard configuration for github to clone. Subsequently, if `ssh git@github.com` is not configured on the machine used for the clone, the fetching of submodules fails.

This commit changes the clone URL to the public https:// version of the repository.


The resulting error for a clone of the unfixed version is as follows:

```
$ git clone https://github.com/score-p/scorep_plugin_metricq/ scorep_plugin_metricq.upstream --recursive
Cloning into 'scorep_plugin_metricq.upstream'...
remote: Enumerating objects: 536, done.
remote: Counting objects: 100% (3/3), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 536 (delta 0), reused 2 (delta 0), pack-reused 533
Receiving objects: 100% (536/536), 99.24 KiB | 2.68 MiB/s, done.
Resolving deltas: 100% (346/346), done.
Submodule 'lib/metricq' (https://github.com/metricq/metricq-cpp.git) registered for path 'lib/metricq'
Submodule 'lib/scorep_plugin_cxx_wrapper' (git@github.com:score-p/scorep_plugin_cxx_wrapper.git) registered for path 'lib/scorep_plugin_cxx_wrapper'
Cloning into '/tmp/scorep_plugin_metricq.upstream/lib/metricq'...
remote: Enumerating objects: 4308, done.
remote: Counting objects: 100% (1101/1101), done.
remote: Compressing objects: 100% (300/300), done.
remote: Total 4308 (delta 755), reused 1052 (delta 723), pack-reused 3207
Receiving objects: 100% (4308/4308), 988.69 KiB | 2.57 MiB/s, done.
Resolving deltas: 100% (2824/2824), done.
Cloning into '/tmp/scorep_plugin_metricq.upstream/lib/scorep_plugin_cxx_wrapper'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:score-p/scorep_plugin_cxx_wrapper.git' into submodule path '/tmp/scorep_plugin_metricq.upstream/lib/scorep_plugin_cxx_wrapper' failed
Failed to clone 'lib/scorep_plugin_cxx_wrapper'. Retry scheduled
Cloning into '/tmp/scorep_plugin_metricq.upstream/lib/scorep_plugin_cxx_wrapper'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:score-p/scorep_plugin_cxx_wrapper.git' into submodule path '/tmp/scorep_plugin_metricq.upstream/lib/scorep_plugin_cxx_wrapper' failed
Failed to clone 'lib/scorep_plugin_cxx_wrapper' a second time, aborting
```