### PR TITLE
Collect per host metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(METRICQ_POSITION_INDEPENDENT_CODE ON CACHE INTERNAL "")
 add_subdirectory(lib)
 
 option(METRICQ_ADVANCED_TIMESYNC "Use advanced time sync capability (needs FFTW3)" OFF)
+option(METRICQ_METRIC_PER_HOST "Use the plugin in 'per_host' instead of 'once' metric collection mode" OFF)
 
 add_library(metricq_plugin
     MODULE
@@ -24,6 +25,10 @@ target_link_libraries(metricq_plugin
         metricq::sink
         metricq::logger-nitro
 )
+
+if(METRICQ_METRIC_PER_HOST)
+    target_compile_definitions(metricq_plugin PRIVATE METRICQ_METRIC_PER_HOST=1)
+endif()
 
 if(METRICQ_ADVANCED_TIMESYNC)
     find_package(FFTW3 REQUIRED)

--- a/README.md
+++ b/README.md
@@ -77,3 +77,33 @@ Because the Score-P default settings are not appropriate for many use-cases:
 
     SCOREP_ENABLE_PROFILING=false
     SCOREP_ENABLE_TRACING=true
+
+
+#### Using the MetricQ plugin in `per_host` mode on ZIH resources
+
+In some situations it is appropriate to switch the MetricQ plugin from `once` mode to `per_host` mode.
+A typical and valid use case is the collection of node-level metrics such as power or energy, where one measurement per physical node is sufficient and semantically correct.
+For most other scenarios, `per_host` mode is discouraged, as it can easily lead to redundant data collection and unnecessary overhead.
+
+To enable `per_host` mode, configure the build as follows:
+
+```
+cmake -DMETRICQ_METRIC_PER_HOST=ON ...
+```
+
+When using `per_host` mode, it is critical to ensure that only the rank(s) associated with a given node request metrics from MetricQ.
+On ZIH systems, this can be achieved by constructing node-specific metric names using SLURM environment variables.
+For example:
+
+```
+EXE="<path/to/my/application>"
+METRIC=power
+
+srun bash -c '
+    export SCOREP_METRIC_METRICQ_PLUGIN=$SLURM_CLUSTER_NAME.$SLURMD_NODENAME.'"$METRIC"'
+    exec '"$EXE"'
+'
+```
+
+This setup guarantees that each node queries only its corresponding MetricQ metric, avoiding duplicate sampling across ranks while preserving correct node-level attribution.
+

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ cmake -DMETRICQ_METRIC_PER_HOST=ON ...
 ```
 
 When using `per_host` mode, it is critical to ensure that only the rank(s) associated with a given node request metrics from MetricQ.
+This is controlled via the variable `SCOREP_METRIC_METRICQ_PLUGIN_PER_HOST_LOCATION`, which specifies the location of the metric.
+
+The value of `SCOREP_METRIC_METRICQ_PLUGIN_PER_HOST_LOCATION` must equal the prefix of the metrics listed in `SCOREP_METRIC_METRICQ_PLUGIN`.
+This design allows the metric location to be specified explicitly without requiring any modification of the metric string passed to `SCOREP_METRIC_METRICQ_PLUGIN`.
+In effect, location and metric name are separated while remaining consistent.
+
 On ZIH systems, this can be achieved by constructing node-specific metric names using SLURM environment variables.
 For example:
 
@@ -101,6 +107,7 @@ METRIC=power
 
 srun bash -c '
     export SCOREP_METRIC_METRICQ_PLUGIN=$SLURM_CLUSTER_NAME.$SLURMD_NODENAME.'"$METRIC"'
+    export SCOREP_METRIC_METRICQ_PLUGIN_PER_HOST_LOCATION=$SLURM_CLUSTER_NAME.$SLURMD_NODENAME
     exec '"$EXE"'
 '
 ```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,11 @@ using handle_oid_policy = object_id<Metric, T, Policies>;
 
 class metricq_plugin : public scorep::plugin::base<metricq_plugin,
                                                    async,
+#ifdef METRICQ_METRIC_PER_HOST
                                                    per_host,
+#else
+                                                   once,
+#endif
                                                    post_mortem,
                                                    scorep_clock,
                                                    handle_oid_policy>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,8 +60,12 @@ void replace_all(std::string& str, const std::string& from, const std::string& t
 template <typename T, typename Policies>
 using handle_oid_policy = object_id<Metric, T, Policies>;
 
-class metricq_plugin : public scorep::plugin::base<metricq_plugin, async, once, post_mortem,
-                                                   scorep_clock, handle_oid_policy>
+class metricq_plugin : public scorep::plugin::base<metricq_plugin,
+                                                   async,
+                                                   per_host,
+                                                   post_mortem,
+                                                   scorep_clock,
+                                                   handle_oid_policy>
 {
 public:
     metricq_plugin()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,18 @@ void replace_all(std::string& str, const std::string& from, const std::string& t
     }
 }
 
+std::string remove_prefix(std::string name, const std::string& prefix)
+{
+    if (name.rfind(prefix, 0) == 0) {              // prefix at position 0
+        name.erase(0, prefix.size());
+        if (!name.empty() && name[0] == '.') {
+            name.erase(0, 1);                      // remove separator
+        }
+    }
+    return name;
+}
+
+
 template <typename T, typename Policies>
 using handle_oid_policy = object_id<Metric, T, Policies>;
 
@@ -118,11 +130,21 @@ public:
             }
 #endif
             auto use_average = use_timesync && average_;
+#ifdef METRICQ_METRIC_PER_HOST
+            std::string metric_prefix = "metricq_";
+            std::string per_host_location_env = scorep::environment_variable::get("PER_HOST_LOCATION", "");
+
+            std::string metric_name = metric_prefix + remove_prefix(name, std::string( per_host_location_env ));
+
+            make_handle(metric_name, Metric{ name, use_timesync, use_average });
+            auto property = scorep::plugin::metric_property(metric_name, meta.description(), meta.unit())
+                                .value_double();
+#else
             make_handle(name, Metric{ name, use_timesync, use_average });
 
             auto property = scorep::plugin::metric_property(name, meta.description(), meta.unit())
                                 .value_double();
-
+#endif
             if (use_average)
             {
                 property.absolute_last();


### PR DESCRIPTION
Development branch only. Will be replaced by a 'proper' solution once 'supra-node' topology can be provided to Score-P.

---

Optionally collect as 'per host' metrics.
Compiletime switch.
Default behavior is not modified.

Closes #8 

As it goes against the discussion in #8 it may or may not be merged.